### PR TITLE
Rename container names for API and Postgres services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   api:
-    container_name: api
+    container_name: challenge-api
     build:
       context: .
       dockerfile: Dockerfile-api
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    container_name: db
+    container_name: challenge-db
     build:
       context: .
       dockerfile: Dockerfile-db


### PR DESCRIPTION
I am moving the server that this project is hosted on to Hetzner. It will share a server with the cloud instance of Eos. We use the same naming for the containers however, so we need to change that.
