### PR TITLE
Update of docker setup, it's been a while

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,36 @@
+# Version control
+.git
+.gitignore
+
+# Docker files
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Environment and secrets
+.env
+.env.*
+
+# Python artifacts
 __pycache__/
 *.pyc
 *.pyo
 *.pyd
-.env
-.git
-.gitignore
-Dockerfile*
+.venv/
+
+# Data and logs
+postgres-data/
 *.log
+
+# IDE and tooling
+.vscode/
+.idea/
+.claude/
+
+# Documentation
+*.md
+LICENSE
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ encrypt.py
 encrypted.txt
 /.vscode
 postgres-data/
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim-bookworm
 # Update OS packages and remove cache to reduce image size
 RUN apt-get update \
     && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -19,6 +20,11 @@ COPY . .
 
 RUN chmod +x entrypoint.sh
 
+RUN useradd --create-home --shell /bin/bash appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+# Actual port is controlled by FLASK_PORT env var at runtime
 EXPOSE 5000
 
 CMD ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -139,15 +139,35 @@ python -m app.run
 
 ### Running with Docker
 
-1. **Build and start containers**:
+1. **Copy the example files** and fill in your values:
 
 ```bash
-docker-compose up --build
+cp .env.EXAMPLE .env
+cp docker-compose.override.EXAMPLE.yml docker-compose.override.yml
 ```
 
-2. **Access the app**: [http://localhost:5000](http://localhost:5000)
+> `docker-compose.override.yml` enables hot-reload via the Flask dev server — edits to `app/` are reflected instantly without rebuilding. Set `SETUP_TYPE=none` inside it to skip DB init on every restart.
+
+2. **Run initial DB setup** (first time only):
+
+```bash
+docker compose run --rm api uv run python setup.py YOUR_DISCORD_ADMIN_USER_ID
+```
+
+3. **Build and start containers**:
+
+```bash
+docker compose up --build
+```
+
+4. **Access the app**: [http://localhost:5000](http://localhost:5000)
 
 > The Flask app connects to PostgreSQL using the hostname defined in `POSTGRES_SERVER` in your `.env`.
+>
+> To run in **production mode** locally (gunicorn, no hot-reload), bypass the override:
+> ```bash
+> docker compose -f docker-compose.yml up --build
+> ```
 
 ---
 

--- a/docker-compose.override.EXAMPLE.yml
+++ b/docker-compose.override.EXAMPLE.yml
@@ -1,0 +1,22 @@
+---
+# Copy this file to docker-compose.override.yml for local development.
+# Docker Compose merges it automatically on `docker compose up`.
+#
+# This enables hot-reload via the Flask dev server — code changes in app/
+# are reflected instantly without rebuilding the image.
+#
+# To run in production mode locally (gunicorn, no hot-reload):
+#   docker compose -f docker-compose.yml up --build
+
+services:
+  api:
+    command: uv run python -m flask run --host=0.0.0.0 --port=${FLASK_PORT:-5000} --reload
+    environment:
+      - FLASK_ENV=development
+      - FLASK_APP=app.run:app
+      - SETUP_TYPE=none
+    volumes:
+      - ./app:/app/app:ro
+    healthcheck:
+      disable: true
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,18 @@ services:
     env_file: .env
     image: adventure-api:latest
     ports:
-      - "${FLASK_PORT}:${FLASK_PORT}"
+      - "${FLASK_PORT:-5000}:${FLASK_PORT:-5000}"
     networks:
       - adventure
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${FLASK_PORT:-5000}/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     restart: unless-stopped
 
   postgres:
@@ -29,7 +35,7 @@ services:
       - adventure
     restart: unless-stopped
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
 
 networks:
   adventure:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,22 @@ if [ "$SETUP_TYPE" = "setup" ] || [ "$SETUP_TYPE" = "update" ]; then
         uv run python update_from_2025.py "$DISCORD_ADMIN_USER_ID"
     fi
 else
-    echo "No DB setup action (SETUP_TYPE=$SETUP_TYPE)"
+    echo "No DB setup action (SETUP_TYPE=${SETUP_TYPE:-unset})"
 fi
 
-echo "Starting gunicorn..."
-exec uv run gunicorn --bind 0.0.0.0:${FLASK_PORT} app.run:app
+# --- Gunicorn Phase ---
+WORKERS=${GUNICORN_WORKERS:-2}
+TIMEOUT=${GUNICORN_TIMEOUT:-120}
+FLASK_PORT=${FLASK_PORT:-5000}
+
+echo "Starting gunicorn (workers=$WORKERS, timeout=$TIMEOUT, port=$FLASK_PORT)..."
+
+exec uv run gunicorn \
+    --bind "0.0.0.0:${FLASK_PORT}" \
+    --workers "$WORKERS" \
+    --timeout "$TIMEOUT" \
+    --graceful-timeout 30 \
+    --access-logfile - \
+    --error-logfile - \
+    --log-level info \
+    app.run:app


### PR DESCRIPTION
  `Dockerfile` 
  - added curl (needed for the health check) and a non-root appuser that owns /app.

  `docker-compose.yml`
  - Added API healthcheck (curl against /, with a 40s start_period to allow setup scripts to finish)
  - Fixed the volumes ./postgres-data (bind mount) postgres-data (named volume)
  - Added :-5000 fallback defaults to all the port mappings

  `docker-compose.override.yml` 
DONT COMMIT THIS (it's bad practice). Treat it like a .env.
picked up automatically by docker compose up, gives developers:
  - Flask dev server with --reload instead of gunicorn
  - ./app mounted live into the container — edit files without rebuilding
  - SETUP_TYPE=none so the DB isn't wiped on every restart

  `entrypoint.sh`
- gunicorn now runs with 2 workers, 120s timeout, graceful shutdown, and full stdout/stderr logging. Worker
  count and timeout are tunable via GUNICORN_WORKERS / GUNICORN_TIMEOUT env vars.

updated some .gitignores and .dockerignores